### PR TITLE
Syntax error line 82: readUIn16LE => readUInt16LE

### DIFF
--- a/obisParser.js
+++ b/obisParser.js
@@ -79,7 +79,7 @@ ObisHeader.prototype = {
             }
         }
         if (i == 1) return buf.readUInt8(0);
-        if (i == 2) return buf.readUIn16LE(0);
+        if (i == 2) return buf.readUInt16LE(0);
         if (i == 3) return buf.readUInt32LE(0);
     }
 }


### PR DESCRIPTION
Syntax error causes #2 - `buf.readUIn16LE is not a function` 